### PR TITLE
Update SimplePay PHP SDK to 2.1.0_200825

### DIFF
--- a/wordpress/furik-plugin/furik/SimplePayV21.php
+++ b/wordpress/furik-plugin/furik/SimplePayV21.php
@@ -46,7 +46,7 @@ class Base
     public $config = [];
     protected $headers = [];
     protected $hashAlgo = 'sha384';
-    public $sdkVersion = 'SimplePay_PHP_SDK_2.0.9_200130';
+    public $sdkVersion = 'SimplePay_PHP_SDK_2.1.0_200825';
     protected $logSeparator = '|';
     protected $logContent = [];
     protected $debugMessage = [];
@@ -75,7 +75,7 @@ class Base
     {
         $this->logContent['runMode'] = strtoupper($this->currentInterface);
         $ver = (float)phpversion();
-        $this->logContent['PHP'] = $ver;
+        $this->logContent['phpVersion'] = $ver;
         if (is_numeric($ver)) {
             if ($ver < 7.0) {
                 $this->phpVersion = 5;
@@ -84,7 +84,7 @@ class Base
     }
 
     /**
-     * Add uniq config field
+     * Add unique config field
      *
      * @param string $key   Config field name
      * @param string $value Vonfig field value
@@ -268,7 +268,7 @@ class Base
     {
         $saltBase = '';
         $chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-        for ($i=1; $i < $length; $i++) {
+        for ($i=0; $i <= $length; $i++) {
             $saltBase .= substr($chars, rand(1, strlen($chars)), 1);
         }
         return hash('md5', $saltBase);
@@ -359,6 +359,12 @@ class Base
         $this->config['api'] = 'live';
         if ($this->config['SANDBOX']) {
             $this->config['api'] = 'sandbox';
+        }
+        $this->logContent['environment'] = strtoupper($this->config['api']);
+
+        $this->config['logger'] = false;
+        if (isset($this->config['LOGGER'])) {
+            $this->config['logger'] = $this->config['LOGGER'];
         }
 
         $this->config['logPath'] = 'log';
@@ -474,8 +480,6 @@ class SimplePayStart extends Base
         'merchant' => '',
         'orderRef' => '',
         'currency' => '',
-        'customerEmail' => '',
-        'language' => '',
         'sdkVersion' => '',
         'methods' => [],
         ];
@@ -707,7 +711,6 @@ class SimplePayIpn extends Base
         $this->writeLog(['ipnConfirm' => 'ipnReturnData provided as content by getIpnConfirmContent']);
         return $this->ipnReturnData;
     }
-
 }
 
 
@@ -1094,6 +1097,10 @@ trait Logger
      */
     public function writeLog($log = [])
     {
+        if (!$this->config['logger']) {
+            return false;
+        }
+
         $write = true;
         if (count($log) == 0) {
             $log = $this->logContent;
@@ -1187,7 +1194,6 @@ trait Logger
         }
         unset($logFile, $logText);
     }
-
 }
 
 
@@ -1222,5 +1228,4 @@ trait Sca
         $this->writeLog(['3DSCheckResult' => 'Card issuer bank wants to identify cardholder (challenge)', '3DSChallengeUrl_ERROR' => 'Missing redirect URL']);
         return false;
     }
-
 }

--- a/wordpress/furik-plugin/furik/SimplePayV21CardStorage.php
+++ b/wordpress/furik-plugin/furik/SimplePayV21CardStorage.php
@@ -1,9 +1,9 @@
 <?php
 
 /**
- *  Copyright (C) 2019 OTP Mobil Kft.
+ *  Copyright (C) 2020 OTP Mobil Kft.
  *
- *  PHP version 7.x
+ *  PHP version 7
  *
  *  This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -21,12 +21,12 @@
  * @category  SDK
  * @package   SimplePayV21
  * @author    SimplePay IT Support <itsupport@otpmobil.com>
- * @copyright 2019 OTP Mobil Kft.
+ * @copyright 2020 OTP Mobil Kft.
  * @license   http://www.gnu.org/licenses/gpl-3.0.html  GNU GENERAL PUBLIC LICENSE (GPL V3.0)
  * @link      http://simplepartner.hu/online_fizetesi_szolgaltatas.html
  */
- 
- 
+
+
  /**
   * Do
   *
@@ -38,6 +38,8 @@
   */
 class SimplePayDo extends Base
 {
+    use Sca;
+
     protected $currentInterface = 'do';
     protected $returnArray = [];
     public $transactionBase = [
@@ -46,7 +48,6 @@ class SimplePayDo extends Base
         'customerEmail' => '',
         'merchant' => '',
         'currency' => '',
-        'customer' => '',
         ];
 
     /**
@@ -56,9 +57,10 @@ class SimplePayDo extends Base
      */
     public function __construct()
     {
+        parent::__construct();
         $this->apiInterface['do'] = '/v2/do';
-    }    
-    
+    }
+
     /**
      * Run Do
      *
@@ -98,9 +100,10 @@ class SimplePayCardQuery extends Base
      */
     public function __construct()
     {
+        parent::__construct();
         $this->apiInterface['cardquery'] = '/v2/cardquery';
-    }    
-    
+    }
+
     /**
      * Run CardQuery
      *
@@ -139,9 +142,10 @@ class SimplePayCardCancel extends Base
      */
     public function __construct()
     {
+        parent::__construct();
         $this->apiInterface['cardcancel'] = '/v2/cardcancel';
-    }    
-    
+    }
+
     /**
      * Run CardCancel
      *
@@ -155,7 +159,7 @@ class SimplePayCardCancel extends Base
 
 
   /**
-   * Recurring for DO
+   * Recurring
    *
    * @category SDK
    * @package  SimplePayV21_SDK
@@ -165,9 +169,9 @@ class SimplePayCardCancel extends Base
    */
 class SimplePayDoRecurring extends Base
 {
-
+    use Sca;
     protected $currentInterface = 'dorecurring';
-    
+
     /**
      * Constructor for dorecurring
      *
@@ -175,9 +179,10 @@ class SimplePayDoRecurring extends Base
      */
     public function __construct()
     {
+        parent::__construct();
         $this->apiInterface['dorecurring'] = '/v2/dorecurring';
-    }    
-    
+    }
+
     /**
      * Run Dorecurring
      *
@@ -189,3 +194,76 @@ class SimplePayDoRecurring extends Base
     }
 }
 
+
+  /**
+   * TokenQuery
+   *
+   * @category SDK
+   * @package  SimplePayV21_SDK
+   * @author   SimplePay IT Support <itsupport@otpmobil.com>
+   * @license  http://www.gnu.org/licenses/gpl-3.0.html  GNU GENERAL PUBLIC LICENSE (GPL V3.0)
+   * @link     http://simplepartner.hu/online_fizetesi_szolgaltatas.html
+   */
+class SimplePayTokenQuery extends Base
+{
+
+    protected $currentInterface = 'tokenquery';
+
+    /**
+     * Constructor for tokenquery
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        $this->apiInterface['tokenquery'] = '/v2/tokenquery';
+    }
+
+    /**
+     * Run Dorecurring
+     *
+     * @return array $result API response
+     */
+    public function runTokenQuery()
+    {
+        return $this->execApiCall();
+    }
+}
+
+
+  /**
+   * TokenCancel
+   *
+   * @category SDK
+   * @package  SimplePayV21_SDK
+   * @author   SimplePay IT Support <itsupport@otpmobil.com>
+   * @license  http://www.gnu.org/licenses/gpl-3.0.html  GNU GENERAL PUBLIC LICENSE (GPL V3.0)
+   * @link     http://simplepartner.hu/online_fizetesi_szolgaltatas.html
+   */
+class SimplePayTokenCancel extends Base
+{
+
+    protected $currentInterface = 'tokencancel';
+
+    /**
+     * Constructor for tokencancel
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        $this->apiInterface['tokencancel'] = '/v2/tokencancel';
+    }
+
+    /**
+     * Run Dorecurring
+     *
+     * @return array $result API response
+     */
+    public function runTokenCancel()
+    {
+        return $this->execApiCall();
+    }
+}


### PR DESCRIPTION
# SimplePay 
## 200603
Increase transaction identifier size
Regulation of transfer days on merchant’s admin interface
Navigation from Simple application to the merchant’s
application
Clarifications

## 200815
Clarifications for 3DS data fields

# SimplePay API v2.1 oneclick and token (recurring) payment
 
## 200115
Adding Strong Customer Authentication (SCA, 3DS)

## 200316
Clarifications of the strong customer authentication process
- do process
- dorecurring process

## 200407
New processes
- Simplified two-step card registration process

## 200529
New processes
- do - API v2 payment with a card stored using API v1
- do - API v2 payment with a card stored in OTP Webshop
(Middleware, MW) service
- tokenquery - query token status
- tokencancel - inactivate token

## 200816
Clarifications
- Strong user authentication
- Introducing threeDSReqAuthMethod

New processes
- Legacy oneclick and recurring card storage